### PR TITLE
Update install snippet to use pyenv root

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Installation
 ------------
 ### Install as a pyenv plugin
 
-    $ git clone https://github.com/doloopwhile/pyenv-register.git ~/.pyenv/plugins/pyenv-register
+    $ git clone https://github.com/doloopwhile/pyenv-register.git $(pyenv root)/plugins/pyenv-register
     $ exec "$SHELL"
 
 Usage


### PR DESCRIPTION
This is quite helpful if you're installing Pyenv into a non-standard location, and/or using a helper like Anyenv or similar.