### PR TITLE
Use venv if present and virtualenv is not.

### DIFF
--- a/bin/pyenv-register
+++ b/bin/pyenv-register
@@ -71,6 +71,11 @@ if "$PYTHON" -c 'import virtualenv' &> /dev/null; then
   "$PYTHON" -m virtualenv -p "$PYTHON" $VIRTUALENV_OPTION "$DEST_DIR" || {
     exit 1
   }
+elif "$PYTHON" -c 'import venv' @> /dev/null; then
+  # Use built-in venv 
+  "$PYTHON" -m venv $VIRTUALENV_OPTION "$DEST_DIR" || {
+    exit 1
+  }
 else
   # Virtualenv is not installed, download script
   echo "virtualenv is not installed to $PYTHON"


### PR DESCRIPTION
As suggested in #2, to try using the built-in `venv` module if `virtualenv` is not present before attempting to install a temporary `virtualenv`.